### PR TITLE
Update for Meteor 0.6.5 compatability

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,6 +3,9 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
+
+	api.use('underscore', 'client');
+
 	api.add_files([
 		'session-extras.js'
 	],'client');

--- a/package.js
+++ b/package.js
@@ -4,7 +4,7 @@ Package.describe({
 
 Package.on_use(function (api) {
 
-	api.use('underscore', 'client');
+	api.use(['underscore','deps','session'], 'client');
 
 	api.add_files([
 		'session-extras.js'


### PR DESCRIPTION
Package changes makes `app.use` a requirement now for dependencies.
